### PR TITLE
workflows: Update schedule

### DIFF
--- a/.github/workflows/fetch-ci-nightly-data.yaml
+++ b/.github/workflows/fetch-ci-nightly-data.yaml
@@ -2,7 +2,7 @@ name: Fetch CI Nightly Data
 run-name: Fetch CI Nightly Data
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 4 * * *'
 jobs:
   fetch-and-commit-data:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Maybe this is unfairly European timezone centric of me, but the nightly tests schedule is to trigger at midnight UTC each day,
https://github.com/kata-containers/kata-containers/blob/main/.github/workflows/ci-nightly.yaml#L4 , so I think we can move the dashboard update earlier, so we have a more up-to-date view sooner. I figure 4am UTC would give us 4 hours to complete the nightlies and if they take longer than that we've got issues with our PR tests, but I'm happy to debate the specifics. It also means more of us can check the dashboard at the start of our days to review problems.