### PR TITLE
workflow: Use bash to fail fast

### DIFF
--- a/.github/workflows/fetch-ci-nightly-data.yaml
+++ b/.github/workflows/fetch-ci-nightly-data.yaml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Update dashboard data
+        # Use bash to fail fast:
+        # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+        shell: bash
         run: |
           # fetch ci nightly data as temporary file
           node scripts/fetch-ci-nightly-data.js | tee tmp-data.json


### PR DESCRIPTION
Currently, if the fetching script fails, the step will be green because there's no fail-fast behavior with the default GHA shell. For example:

https://github.com/kata-containers/kata-containers.github.io/actions/runs/11674542121/job/32507427396

So we switch to an explicit bash to address this and fail the entire run (see docs linked in code).