### PR TITLE
dashboard: Fetch data whenever a PR is merged into main

### DIFF
--- a/.github/workflows/fetch-ci-nightly-data.yaml
+++ b/.github/workflows/fetch-ci-nightly-data.yaml
@@ -4,6 +4,14 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
+  on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/fetch-ci-nightly-data.js'
+      - '.github/workflows/fetch-ci-nightly-data.yaml'
+
 
 jobs:
   fetch-and-commit-data:


### PR DESCRIPTION
**MUST:**
- [ ]  Add token to Github secrets to increase rate limits for fetch scripts 
- [x] Confirm whether to track the .yaml script for the fetch workflow 
  - And whether to keep the commented out PR fetch script as a note

**Context:**
If we merge a PR to main that assumes that new data is required (e.g. the PR runs view feature), the website will be updated immediately, but the data will take up to 24 hours to refresh. However, we need the new data.

**Solution:** 
On any push to the main branch that updates "*scripts/fetch-ci-data-nightly.js*", the fetch workflow will be triggered (includes merges).

**ADDITIONAL:**
Since the Nightly tests are only run nightly, we only need to fetch the script once a day. 
The PR data changes whenever a PR is made, so we could add:

```
  pull_request:
    branches:
      - main
```
This will fetch data whenever a new PR is made (might need to set a delay to let tests finish)