### PR TITLE
dashboard: Change skip icon

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -103,7 +103,7 @@ export default function Home() {
                   ? "✅"
                   : run.result === "Fail"
                   ? "❌"
-                  : "⚠️";
+                  : "⏹️";
               return (
                 <span key={`${job.name}-runs-${run.run_num}`}>
                   <a href={run.url}>


### PR DESCRIPTION
Use a more neutral icon as a skipped test should mostly mean that an earlier test has failed, not that there is an issue with the current test.