### PR TITLE
dashboard: Add Maintainers List

### DIFF
--- a/maintainers.yml
+++ b/maintainers.yml
@@ -1,0 +1,76 @@
+# maintainers.yaml
+#
+# @kata-containers/arch-s390x: BbolroC
+# @kata-containers/arch-ppc64le: Amulyam24?
+# @kata-containers/cri-o: ?
+# @kata-containers/dragonball: bergwolf
+# @kata-containers/rust: pmores, lifupan
+# @kata-containers/amd: AdithyaKrishnan, arvindskumar99
+
+
+## slack: member id, display name, or link to profile?
+
+mappings:
+  # @kata-containers/arch-s390x: BbolroC
+  - regex: ".*s390x.*"
+    group: "Arch-s390x"
+    owners:
+      - fullname: "Hyounggyu Choi"
+        email: "Hyounggyu.Choi@ibm.com"
+        slackurl: "https://katacontainers.slack.com/team/U0369UMM69M"
+        slack: "Hyounggyu Choi"
+        github: "BbolroC"
+
+  # @kata-containers/arch-ppc64le: Amulyam24?
+  - regex: ".*ppc64le.*"
+    group: "Arch-ppc64le"
+    owners:
+      - fullname: "Amulya Meka"
+        email: "amulmek1@in.ibm.com"
+        slackurl: "https://katacontainers.slack.com/team/UV7RP34GK"
+        slack: "Amulyam24"
+        github: "Amulyam24"
+
+
+  # @kata-containers/dragonball: bergwolf
+  - regex: ".*dragonball.*"
+    group: "Dragonball"
+    owners:
+      - fullname: "Peng Tao"
+        email: "http://bergwolf.github.io/"
+        slackurl: "https://katacontainers.slack.com/team/U8709NBSM"
+        slack: "bergwolf"
+        github: "bergwolf"
+
+
+  # @kata-containers/rust: pmores, lifupan
+  - regex: ".*runtime-rs.*"
+    group: "Rust"
+    owners:
+      - fullname: "Pavel Mores"
+        email: "pmores@redhat.com"
+        slackurl: "https://katacontainers.slack.com/team/U03CCR6KGBC"
+        slack: "Pavel Mores"
+        github: "pmores"
+
+      - fullname: "Fupan Li"
+        email: "lifupan@gmail.com"
+        slackurl: "https://katacontainers.slack.com/team/U059Y60DZPW"
+        slack: "fupan li"
+        github: "lifupan"
+
+# @kata-containers/amd: AdithyaKrishnan, arvindskumar99
+  - regex: ".*(qemu-(sev(-snp)?|snp(-experimental)?)|ovmf(-sev)?).*"
+    group: "AMD"
+    owners:
+      - fullname: "Adithya Krishnan Kannan"
+        email: "AdithyaKrishnan.Kannan@amd.com"
+        slackurl: "https://cloud-native.slack.com/team/U05TX2URB16"
+        slack: "Adi"
+        github: "AdithyaKrishnan"
+
+      - fullname: "Arvind Kumar"
+        email: "arvind.kumar@amd.com"
+        slackurl: "https://cloud-native.slack.com/team/U06HXU0312P"
+        slack: "Arvind Kumar"
+        github: "arvindskumar99"

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,12 @@ module.exports = {
     unoptimized: true,
   },
   webpack: (config, { dev }) => {
+
+    config.module.rules.push({
+      test: /\.yml$/,
+      use: 'yaml-loader',
+    });
+    
     if (dev) {
       config.devtool = false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "primereact": "^10.8.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-transition-group": "^4.4.5"
+        "react-transition-group": "^4.4.5",
+        "yaml-loader": "^0.8.1"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
@@ -1461,6 +1462,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1994,6 +2004,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -3706,6 +3725,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/javascript-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+      "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
@@ -3845,6 +3870,32 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/loader-utils/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -5952,10 +6003,23 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
       "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yaml-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.8.1.tgz",
+      "integrity": "sha512-BCEndnUoi3BaZmePkwGGe93txRxLgMhBa/gE725v1/GHnura8QvNs7c4+4C1yyhhKoj3Dg63M7IqhA++15j6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "javascript-stringify": "^2.0.1",
+        "loader-utils": "^2.0.0",
+        "yaml": "^2.0.0"
       },
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "primereact": "^10.8.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-transition-group": "^4.4.5"
+    "react-transition-group": "^4.4.5",
+    "yaml-loader": "^0.8.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Needed 
- [x] Merge #20 before this
  - For instance, the changes to the basePath in deploy.yml/next.config.js is done in that PR. We assume these changes. 

## Description
- Added Maintainer information to the rowExpansionTemplate
  - If none exist, a message appears
  - If multiple exist (across groups as well), all names are listed
  - Clicking on the name takes you to their Github
  - On hover, an overlay panel appear with more information
    - Including: Group, Email, Github, and Slack
      - Github and slack are clickable links 


## Testing
- [x] Tested in dev
- [x] Tested in prod

### Example of Maintainer's List
![image](https://github.com/user-attachments/assets/069d329c-4749-40d9-ba1a-6748f0f3c5a7)


### Example of Overlay Panel
![image](https://github.com/user-attachments/assets/fb50abcb-0883-45a4-a833-06261c59110f)

