### PR TITLE
ui: Open job links in new tab

### DIFF
--- a/components/Dashboard.js
+++ b/components/Dashboard.js
@@ -152,7 +152,7 @@ export default function Dashboard({ coco = false }) {
                   : "⚠️";
               return (
                 <span key={`${job.name}-runs-${run.run_num}`}>
-                  <a href={run.url}>
+                  <a href={run.url} target="_blank" rel="noopener noreferrer">
                     {emoji} {run.run_num}
                   </a>
                   &nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
It seems that Github recently changed their iframe origin policy, meaning that opening links in the same iframe/tab doesn't work anymore.  To address this, we now open all links in a new tab.