### PR TITLE
maintainers: Add Sumedh as agent-ctl maintainer

### DIFF
--- a/maintainers.yml
+++ b/maintainers.yml
@@ -116,3 +116,13 @@ mappings:
         slackurl: "https://katacontainers.slack.com/team/UU8N67ZN1"
         slack: "Fabiano Fidêncio"
         github: "fidencio"
+
+  # Sumedh maintains the agent-ctl tests.
+  - regex: ".*run-kata-agent-apis.*"
+    group: "agent-ctl"
+    owners:
+      - fullname: "Sumedh Alok Sharma"
+        email: "sumsharma@microsoft.com"
+        slackurl: "https://katacontainers.slack.com/archives/D08UUBKH42F"
+        slack: "Sumedh Alok Sharma"
+        github: "Sumynwa"


### PR DESCRIPTION
This adds Sumedh as the maintainer for the agent-ctl tests.